### PR TITLE
make harfbuzz default renderer

### DIFF
--- a/src/fencer.js
+++ b/src/fencer.js
@@ -23,9 +23,9 @@ const GLOBAL = {
 	fontBuffer: undefined,
 	instances: [],
 	renderers: {
+		harfbuzz: "harfbuzz",
 		browser: "browser",
 		polyfill: "simple polyfill",
-		harfbuzz: "harfbuzz",
 		samsa: "samsa",
 	},
 	renderFontSize: 200,


### PR DESCRIPTION
The only renderer that currently works for me is harfbuzz. Imo it makes sense if this is the default upon load.